### PR TITLE
refactor(cache): consolidate cache managers into internal/cache with improved naming

### DIFF
--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -61,7 +61,7 @@ func runClear(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get current stats before clearing
-	var stats *cache.UnifiedStats
+	var stats []cache.Stats
 	if !quiet {
 		stats, err = manager.GetAllStats()
 		if err != nil {
@@ -74,32 +74,31 @@ func runClear(cmd *cobra.Command, args []string) error {
 		fmt.Println("Cache entries to be cleared:")
 		fmt.Println("============================")
 		fmt.Println()
-
-		if clearAll || clearBuild {
-			fmt.Printf("📦 Build Cache:  %s (%s entries)\n",
-				cache.FormatBytes(stats.BuildCache.Size),
-				cache.FormatCount(stats.BuildCache.EntryCount))
-		}
-		if clearAll || clearMod {
-			fmt.Printf("📚 Module Cache: %s (%s modules)\n",
-				cache.FormatBytes(stats.ModCache.Size),
-				cache.FormatCount(stats.ModCache.ModuleCount))
-		}
-		if clearAll || clearTest {
-			fmt.Printf("🧪 Test Cache:   %s (%s entries)\n",
-				cache.FormatBytes(stats.TestCache.Size),
-				cache.FormatCount(stats.TestCache.EntryCount))
-		}
-
 		totalSize := int64(0)
-		if clearAll || clearBuild {
-			totalSize += stats.BuildCache.Size
-		}
-		if clearAll || clearMod {
-			totalSize += stats.ModCache.Size
-		}
-		if clearAll || clearTest {
-			totalSize += stats.TestCache.Size
+		for _, stat := range stats {
+			switch stat := stat.(type) {
+			case *cache.BuildCacheStats:
+				if clearAll || clearBuild {
+					totalSize += stat.Size
+					fmt.Printf("Build Cache:  %s (%s entries)\n",
+						cache.FormatBytes(stat.Size),
+						cache.FormatCount(stat.EntryCount))
+				}
+			case *cache.ModCacheStats:
+				if clearAll || clearMod {
+					totalSize += stat.Size
+					fmt.Printf("Module Cache: %s (%s modules)\n",
+						cache.FormatBytes(stat.Size),
+						cache.FormatCount(stat.ModuleCount))
+				}
+			case *cache.TestCacheStats:
+				if clearAll || clearTest {
+					totalSize += stat.Size
+					fmt.Printf("Test Cache:   %s (%s entries)\n",
+						cache.FormatBytes(stat.Size),
+						cache.FormatCount(stat.EntryCount))
+				}
+			}
 		}
 
 		fmt.Println()
@@ -153,20 +152,20 @@ func runClear(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 
 		if clearAll || clearBuild {
-			fmt.Printf("📦 Build Cache:  %s entries deleted\n", cache.FormatCount(result.BuildDeleted))
+			fmt.Printf("Build Cache:  %s entries deleted\n", cache.FormatCount(result.BuildDeleted))
 		}
 		if clearAll || clearMod {
-			fmt.Printf("📚 Module Cache: %s entries deleted\n", cache.FormatCount(result.ModulesDeleted))
+			fmt.Printf("Module Cache: %s entries deleted\n", cache.FormatCount(result.ModulesDeleted))
 		}
 		if clearAll || clearTest {
-			fmt.Printf("🧪 Test Cache:   %s entries deleted\n", cache.FormatCount(result.TestDeleted))
+			fmt.Printf("Test Cache:   %s entries deleted\n", cache.FormatCount(result.TestDeleted))
 		}
 
 		fmt.Println()
 		fmt.Printf("Total space freed: %s\n", cache.FormatBytes(result.TotalFreed))
 
 		if result.Errors > 0 {
-			fmt.Printf("\n⚠️  Warning: %d errors occurred during clearing\n", result.Errors)
+			fmt.Printf("\n Warning: %d errors occurred during clearing\n", result.Errors)
 		}
 	}
 

--- a/internal/cache/build_manager.go
+++ b/internal/cache/build_manager.go
@@ -1,4 +1,4 @@
-package buildcache
+package cache
 
 import (
 	"fmt"
@@ -6,19 +6,19 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/muhammadali7768/gocachectl/internal/cache"
 )
 
 // Manager manages the Go build cache
-type Manager struct {
+type BuildManager struct {
 	cacheDir string
 }
 
+var _ CacheManager = (*BuildManager)(nil)
+
 // NewManager creates a new build cache manager
-func NewManager(cacheDir string) (*Manager, error) {
+func NewBuildManager(cacheDir string) (*BuildManager, error) {
 	if cacheDir == "" {
-		dir, err := cache.GetGoEnv("GOCACHE")
+		dir, err := GetGoEnv("GOCACHE")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get GOCACHE: %w", err)
 		}
@@ -30,14 +30,14 @@ func NewManager(cacheDir string) (*Manager, error) {
 		return nil, fmt.Errorf("build cache directory does not exist: %s", cacheDir)
 	}
 
-	return &Manager{
+	return &BuildManager{
 		cacheDir: cacheDir,
 	}, nil
 }
 
 // GetStats retrieves build cache statistics
-func (m *Manager) GetStats() (*cache.BuildCacheStats, error) {
-	stats := &cache.BuildCacheStats{
+func (m *BuildManager) GetStats() (Stats, error) {
+	stats := &BuildCacheStats{
 		Location:    m.cacheDir,
 		OldestEntry: time.Now(),
 	}
@@ -106,7 +106,7 @@ func (m *Manager) GetStats() (*cache.BuildCacheStats, error) {
 }
 
 // Clear removes all build cache entries
-func (m *Manager) Clear() (int, int64, error) {
+func (m *BuildManager) Clear() (int, int64, error) {
 	var deletedCount int
 	var freedSpace int64
 
@@ -147,6 +147,6 @@ func (m *Manager) Clear() (int, int64, error) {
 }
 
 // GetLocation returns the cache directory path
-func (m *Manager) GetLocation() string {
+func (m *BuildManager) GetLocation() string {
 	return m.cacheDir
 }

--- a/internal/cache/interfaces.go
+++ b/internal/cache/interfaces.go
@@ -1,0 +1,11 @@
+package cache
+
+type Stats interface {
+	Type() string
+}
+
+type CacheManager interface {
+	GetStats() (Stats, error)
+	Clear() (int, int64, error)
+	GetLocation() string
+}

--- a/internal/cache/test_manager.go
+++ b/internal/cache/test_manager.go
@@ -1,4 +1,4 @@
-package testcache
+package cache
 
 import (
 	"fmt"
@@ -7,19 +7,19 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/muhammadali7768/gocachectl/internal/cache"
 )
 
 // Manager manages the Go test cache (part of build cache)
-type Manager struct {
+type TestManager struct {
 	cacheDir string
 }
 
+var _ CacheManager = (*TestManager)(nil)
+
 // NewManager creates a new test cache manager
-func NewManager(cacheDir string) (*Manager, error) {
+func NewTestManager(cacheDir string) (*TestManager, error) {
 	if cacheDir == "" {
-		dir, err := cache.GetGoEnv("GOCACHE")
+		dir, err := GetGoEnv("GOCACHE")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get GOCACHE: %w", err)
 		}
@@ -31,14 +31,14 @@ func NewManager(cacheDir string) (*Manager, error) {
 		return nil, fmt.Errorf("test cache directory does not exist: %s", cacheDir)
 	}
 
-	return &Manager{
+	return &TestManager{
 		cacheDir: cacheDir,
 	}, nil
 }
 
 // GetStats retrieves test cache statistics
-func (m *Manager) GetStats() (*cache.TestCacheStats, error) {
-	stats := &cache.TestCacheStats{
+func (m *TestManager) GetStats() (Stats, error) {
+	stats := &TestCacheStats{
 		Location:    m.cacheDir,
 		OldestEntry: time.Now(),
 	}
@@ -95,7 +95,7 @@ func (m *Manager) GetStats() (*cache.TestCacheStats, error) {
 }
 
 // Clear removes test cache entries
-func (m *Manager) Clear() (int, int64, error) {
+func (m *TestManager) Clear() (int, int64, error) {
 	var deletedCount int
 	var freedSpace int64
 
@@ -136,7 +136,7 @@ func (m *Manager) Clear() (int, int64, error) {
 }
 
 // GetLocation returns the cache directory path
-func (m *Manager) GetLocation() string {
+func (m *TestManager) GetLocation() string {
 	return m.cacheDir
 }
 

--- a/internal/cache/types.go
+++ b/internal/cache/types.go
@@ -2,15 +2,6 @@ package cache
 
 import "time"
 
-// UnifiedStats contains statistics for all Go caches
-type UnifiedStats struct {
-	BuildCache BuildCacheStats `json:"build_cache"`
-	ModCache   ModCacheStats   `json:"module_cache"`
-	TestCache  TestCacheStats  `json:"test_cache"`
-	TotalSize  int64           `json:"total_size"`
-	TotalCount int             `json:"total_count"`
-}
-
 // BuildCacheStats contains build cache statistics
 type BuildCacheStats struct {
 	Location     string           `json:"location"`
@@ -39,6 +30,10 @@ type TestCacheStats struct {
 	OldestEntry time.Time `json:"oldest_entry"`
 	NewestEntry time.Time `json:"newest_entry"`
 }
+
+func (s BuildCacheStats) Type() string { return "build" }
+func (s ModCacheStats) Type() string   { return "module" }
+func (s TestCacheStats) Type() string  { return "test" }
 
 // SizeDistribution tracks distribution of cache entries by size
 type SizeDistribution struct {


### PR DESCRIPTION
Moved all cache manager implementations into internal/cache and renamed structs to idiomatic names. Added a shared CacheManager interface. Simplified folder structure and improved maintainability.